### PR TITLE
Modified to work on WLS 12.1.3 using JAX-RS 2.0 shared-library via refer...

### DIFF
--- a/web/nb-configuration.xml
+++ b/web/nb-configuration.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project-shared-configuration>
+    <!--
+This file contains additional configuration written by modules in the NetBeans IDE.
+The configuration is intended to be shared among all the users of project and
+therefore it is assumed to be part of version control checkout.
+Without this configuration present, some functionality in the IDE may be limited or fail altogether.
+-->
+    <properties xmlns="http://www.netbeans.org/ns/maven-properties-data/1">
+        <!--
+Properties that influence various parts of the IDE, especially code formatting and the like. 
+You can copy and paste the single properties, into the pom.xml file and the IDE will pick them up.
+That way multiple projects can share the same settings (useful for formatting rules for example).
+Any value defined here will override the pom.xml file value but is only applicable to the current project.
+-->
+        <org-netbeans-modules-maven-jaxws.rest_2e_config_2e_type>ide</org-netbeans-modules-maven-jaxws.rest_2e_config_2e_type>
+    </properties>
+</project-shared-configuration>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -111,14 +111,21 @@
             </dependencies>
         </profile>
         <profile>
-            <id>weblogic</id>
+            <id>weblogic-12.2.1</id>
             <dependencies>
                 <dependency>
+                    <groupId>com.oracle.weblogic</groupId>
+                    <artifactId>weblogic-server-pom</artifactId>
+                    <version>12.1.3-0-0</version>
+                    <type>pom</type>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
                     <groupId>org.jboss.arquillian.container</groupId>
-                    <artifactId>arquillian-wls-remote-12.1</artifactId>
+                    <artifactId>arquillian-wls-remote-12.1.2</artifactId>
                     <version>1.0.0.Alpha3</version>
                     <scope>test</scope>
-                </dependency>
+                </dependency> 
             </dependencies>
             <build>
                 <plugins>
@@ -128,13 +135,49 @@
                         <version>2.18.1</version>
                         <configuration>
                             <systemPropertyVariables>
-                                <arquillian.launch>weblogic</arquillian.launch>
+                                <arquillian.launch>weblogic-12.2.1</arquillian.launch>
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>
                 </plugins>
             </build>
         </profile>
+        
+        <profile>
+            <id>weblogic-12.1.3</id>
+            <dependencies>
+                <dependency>
+                    <groupId>com.oracle.weblogic</groupId>
+                    <artifactId>weblogic-server-pom</artifactId>
+                    <version>12.1.3-0-0</version>
+                    <type>pom</type>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.arquillian.container</groupId>
+                    <artifactId>arquillian-wls-remote-12.1.2</artifactId>
+                    <version>1.0.0.Alpha3</version>
+                    <scope>test</scope>
+                </dependency> 
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.18.1</version>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <arquillian.launch>weblogic-12.1.3</arquillian.launch>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        
+        
+        
     </profiles>
 
 </project>

--- a/web/src/main/webapp/WEB-INF/weblogic.xml
+++ b/web/src/main/webapp/WEB-INF/weblogic.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<weblogic-web-app xmlns="http://xmlns.oracle.com/weblogic/weblogic-web-app"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.oracle.com/weblogic/weblogic-web-app http://xmlns.oracle.com/weblogic/weblogic-web-app/1.0/weblogic-web-app.xsd">
+    
+    <library-ref>
+       <library-name>jax-rs</library-name>
+       <specification-version>2.0</specification-version>
+       <exact-match>false</exact-match>
+    </library-ref>
+</weblogic-web-app>

--- a/web/src/test/java/com/example/foo/web/FooResourceTest.java
+++ b/web/src/test/java/com/example/foo/web/FooResourceTest.java
@@ -31,11 +31,14 @@ public class FooResourceTest {
                 .resolve("com.example.foo:bean").withoutTransitivity()
                 .asFile();
 
-        return ShrinkWrap.create(WebArchive.class)
+        WebArchive war = ShrinkWrap.create(WebArchive.class)
                 .addAsLibraries(libs)
                 .addClasses(RestApp.class, FooResource.class)
                 .addPackage(Application.class.getPackage())
+                .addAsWebInfResource(new File("src/main/webapp/WEB-INF", "weblogic.xml"))
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+        System.out.println(war.toString(true));
+        return war;
     }
 
     @Test

--- a/web/src/test/resources/arquillian.xml
+++ b/web/src/test/resources/arquillian.xml
@@ -2,19 +2,41 @@
 <arquillian xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xmlns="http://jboss.org/schema/arquillian"
             xsi:schemaLocation="http://jboss.org/schema/arquillian http://www.jboss.org/schema/arquillian/arquillian_1_0.xsd">
-
+    <!--
     <container qualifier="weblogic">
         <configuration>
             <property name="adminUrl">t3://localhost:7001</property>
             <property name="adminUserName">weblogic</property>
             <property name="adminPassword">weblogic1</property>
             <property name="target">AdminServer</property>
-            <property name="weblogicJarPath">
-                /home/kubam/workspaces/szkolenia/workspaces/workspace_20150202-nordea/weblogic-docker/wls1213/wlserver/server/lib/weblogic.jar
-            </property>
-            <property name="wlHome">
-                /home/kubam/workspaces/szkolenia/workspaces/workspace_20150202-nordea/weblogic-docker/wls1213/wlserver
-            </property>
+            <property name="wlHome">/tmp/wls12210_0128/wlserver </property>
+        </configuration>
+    </container>
+    -->
+
+    <engine>
+        <property name="deploymentExportPath">target/</property>
+    </engine>
+
+
+    <container qualifier="weblogic-12.2.1" >
+        <defaultProtocol type="Servlet 3.0" />
+        <configuration>
+            <property name="wlHome">/tmp/wls12210_0128/wlserver</property>
+            <property name="adminUrl">t3://localhost:7001</property>
+            <property name="adminUserName">weblogic</property>
+            <property name="adminPassword">welcome1</property>
+            <property name="target">AdminServer</property>
+        </configuration>
+    </container>
+    <container qualifier="weblogic-12.1.3" >
+        <defaultProtocol type="Servlet 3.0" />
+        <configuration>
+            <property name="wlHome">/Users/sbutton/Oracle/Middleware/wlserver</property>
+            <property name="adminUrl">t3://localhost:7002</property>
+            <property name="adminUserName">weblogic</property>
+            <property name="adminPassword">welcome1</property>
+            <property name="target">AdminServer</property>
         </configuration>
     </container>
 


### PR DESCRIPTION
This now works for me on WLS 12.1.3 - the original build.  Haven't tried Update 1 but should be the same.
I deployed the $ORACLE_HOME/wlserver/common/deployable-libraries/jaxrs-2.0.war to the target server.
Added a weblogic.xml to the web module to reference the jax-rs:2.0 shared library.
Modified FooTestResource.java to add weblogic.xml to the test deployment archive.
Modified arquillian.xml to add two WLS profiles - one for WLS 12.1.3 and one for our WLS 12.2.1 release currently under development (Java EE 7 implementation where tests worked with no changes at all).
Modified web/pom.xml to add profiles to use the container definitions - can deploy to weblogic-12.1.3 or weblogic-12.2.1 from same project for comparison testing.
